### PR TITLE
ヘッダーとフッターをテンプレート化

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,17 @@
+<footer class="footer">
+  <div class="container-fluid">
+    <div class="links-section">
+      <a href="/privacy/">プライバシーポリシー</a>
+    </div>
+    <!-- .links-section -->
+    <div class="copyright-section">
+      <div class="copytext">
+        &copy; <span id="copyright-year"></span> 滝沢ハッカソン運営委員会 | Design by <a href="https://uicookies.com">uiCookies</a>
+        and modify by <a href="https://github.com/rkonno">rkonno</a>
+      </div>
+    </div>
+    <!-- .copyright-section -->
+  </div>
+  </div>
+</footer>
+<!-- .footer -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,8 +19,6 @@
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse navbar-right navbar-main-collapse">
         <ul class="nav navbar-nav">
-          <!-- Hidden li included to remove active class from about link when scrolled up past about section -->
-          <li class="hidden"><a href="#page-top"></a></li>
           <li><a href="/#section-faq-position">初めて参加される方へ</a></li>
           <li><a href="/sponsorship/">スポンサー募集</a>
           <li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,38 @@
+<header class="header">
+  <!-- Navigation -->
+  <nav class="navbar main-menu" role="navigation">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand page-scroll" href="/">
+          <svg class="navbar-brand-svg">
+            <use xlink:href="#logo" />
+          </svg>
+        </a>
+      </div>
+
+      <!-- Collect the nav links, forms, and other content for toggling -->
+      <div class="collapse navbar-collapse navbar-right navbar-main-collapse">
+        <ul class="nav navbar-nav">
+          <!-- Hidden li included to remove active class from about link when scrolled up past about section -->
+          <li class="hidden"><a href="#page-top"></a></li>
+          <li><a href="/#section-faq-position">初めて参加される方へ</a></li>
+          <li><a href="/sponsorship/">スポンサー募集</a>
+          <li>
+          <li><a href="/about/">ABOUT</a></li>
+          <li><a href="/team/">TEAM</a></li>
+        </ul>
+      </div>
+      <!-- /.navbar-collapse -->
+    </div>
+    <!-- /.container -->
+  </nav>
+
+  <!-- .nav -->
+
+</header>

--- a/_layouts/homepage_article.html
+++ b/_layouts/homepage_article.html
@@ -95,23 +95,7 @@
 
     {{ content }}
 
-    <footer class="footer">
-      <div class="container-fluid">
-        <div class="links-section">
-            <a href="/privacy/">プライバシーポリシー</a>
-          </div>
-          <!-- .links-section -->
-          <div class="copyright-section">
-            <div class="copytext">
-              &copy; <span id="copyright-year"></span> 滝沢ハッカソン運営委員会 | Design by <a href="https://uicookies.com">uiCookies</a> and modify by <a
-                href="https://github.com/rkonno">rkonno</a>
-            </div>
-          </div>
-          <!-- .copyright-section -->
-        </div>
-      </div>
-    </footer>
-    <!-- .footer -->
+    {% include footer.html %}
 
   </div>
   <!-- #main-wrapper -->

--- a/_layouts/homepage_article.html
+++ b/_layouts/homepage_article.html
@@ -83,43 +83,7 @@
 
   <div id="main-wrapper" class="simple-page">
 
-    <header class="header">
-      <!-- Navigation -->
-      <nav class="navbar main-menu" role="navigation">
-        <div class="container">
-          <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">
-              <span class="sr-only">Toggle navigation</span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-            </button>
-            <a class="navbar-brand page-scroll" href="/">
-              <svg class="navbar-brand-svg">
-                <use xlink:href="#logo" />
-              </svg>
-            </a>
-          </div>
-
-          <!-- Collect the nav links, forms, and other content for toggling -->
-          <div class="collapse navbar-collapse navbar-right navbar-main-collapse">
-            <ul class="nav navbar-nav">
-              <!-- Hidden li included to remove active class from about link when scrolled up past about section -->
-              <li class="hidden"><a href="#page-top"></a></li>
-              <li><a href="/#section-faq-position">初めて参加される方へ</a></li>
-              <li><a href="/sponsorship/">スポンサー募集</a><li>
-              <li><a href="/about/">ABOUT</a></li>
-              <li><a href="/team/">TEAM</a></li>
-            </ul>
-          </div>
-          <!-- /.navbar-collapse -->
-        </div>
-        <!-- /.container -->
-      </nav>
-
-      <!-- .nav -->
-
-    </header>
+    {% include header.html %}
 
     <div class="orig-jumbotron" id="background-particles">
       <div class="content">

--- a/index.html
+++ b/index.html
@@ -1,3 +1,6 @@
+---
+---
+
 <!DOCTYPE html>
 <html>
 
@@ -75,41 +78,7 @@
       </div>
     </div>
 
-    <header class="header">
-      <!-- Navigation -->
-      <nav class="navbar main-menu" role="navigation">
-        <div class="container">
-          <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">
-              <span class="sr-only">Toggle navigation</span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-            </button>
-            <a class="navbar-brand page-scroll" href="#page-top">
-              <svg class="navbar-brand-svg">
-                <use xlink:href="#logo" />
-              </svg>
-            </a>
-          </div>
-
-          <!-- Collect the nav links, forms, and other content for toggling -->
-          <div class="collapse navbar-collapse navbar-right navbar-main-collapse">
-            <ul class="nav navbar-nav">
-              <li><a href="/#section-faq-position">初めて参加される方へ</a></li>
-              <li><a href="/sponsorship/">スポンサー募集</a><li>
-              <li><a href="/about/">ABOUT</a></li>
-              <li><a href="/team/">TEAM</a></li>
-            </ul>
-          </div>
-          <!-- /.navbar-collapse -->
-        </div>
-        <!-- /.container -->
-      </nav>
-
-      <!-- .nav -->
-
-    </header>
+    {% include header.html %}
 
     <div class="orig-jumbotron" id="background-particles">
       <div class="content content-one">

--- a/index.html
+++ b/index.html
@@ -551,23 +551,7 @@
     </div>
   </section>
 
-  <footer class="footer">
-    <div class="container-fluid">
-      <div class="links-section">
-          <a href="/privacy/">プライバシーポリシー</a>
-        </div>
-        <!-- .links-section -->
-        <div class="copyright-section">
-          <div class="copytext">
-            &copy; <span id="copyright-year"></span> 滝沢ハッカソン運営委員会 | Design by <a href="https://uicookies.com">uiCookies</a> and modify by <a
-              href="https://github.com/rkonno">rkonno</a>
-          </div>
-        </div>
-        <!-- .copyright-section -->
-      </div>
-    </div>
-  </footer>
-  <!-- .footer -->
+  {% include footer.html %}
 
   </div>
   <!-- #main-wrapper -->

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,3 +1,6 @@
+---
+---
+
 <!DOCTYPE html>
 <html>
 
@@ -69,43 +72,7 @@
     </svg>
 
     <div id="main-wrapper" class="simple-page">
-        <header class="header">
-            <!-- Navigation -->
-            <nav class="navbar main-menu" role="navigation">
-                <div class="container">
-                    <div class="navbar-header">
-                        <button type="button" class="navbar-toggle" data-toggle="collapse"
-                            data-target=".navbar-main-collapse">
-                            <span class="sr-only">Toggle navigation</span>
-                            <span class="icon-bar"></span>
-                            <span class="icon-bar"></span>
-                            <span class="icon-bar"></span>
-                        </button>
-                        <a class="navbar-brand page-scroll" href="/">
-                            <svg class="navbar-brand-svg">
-                                <use xlink:href="#logo" />
-                            </svg>
-                        </a>
-                    </div>
-
-                    <!-- Collect the nav links, forms, and other content for toggling -->
-                    <div class="collapse navbar-collapse navbar-right navbar-main-collapse">
-                        <ul class="nav navbar-nav">
-                            <!-- Hidden li included to remove active class from about link when scrolled up past about section -->
-                            <li class="hidden"><a href="#page-top"></a></li>
-                            <li><a href="/#section-faq-position">初めて参加される方へ</a></li>
-                            <li><a href="/sponsorship/">スポンサー募集</a><li>
-                            <li><a href="/about/">ABOUT</a></li>
-                            <li><a href="/team/">TEAM</a></li>
-                        </ul>
-                    </div>
-                    <!-- /.navbar-collapse -->
-                </div>
-                <!-- /.container -->
-            </nav>
-
-            <!-- .nav -->
-        </header>
+        {% include header.html %}
 
         <div class="orig-jumbotron" id="background-particles">
             <div class="content">
@@ -157,23 +124,7 @@
             </div>
         </article>
 
-        <footer class="footer">
-            <div class="container-fluid">
-              <div class="links-section">
-                  <a href="/privacy/">プライバシーポリシー</a>
-                </div>
-                <!-- .links-section -->
-                <div class="copyright-section">
-                  <div class="copytext">
-                    &copy; <span id="copyright-year"></span> 滝沢ハッカソン運営委員会 | Design by <a href="https://uicookies.com">uiCookies</a> and modify by <a
-                      href="https://github.com/rkonno">rkonno</a>
-                  </div>
-                </div>
-                <!-- .copyright-section -->
-              </div>
-            </div>
-          </footer>
-          <!-- .footer -->
+        {% include footer.html %}
     </div>
     <!-- #main-wrapper -->
 


### PR DESCRIPTION
## 変更点

- 記事コンテンツ
- トップページ

のヘッダー&フッターをテンプレート化して共通化しました。

そのため、サイトのコンテンツ自体への変更点はありません。
（なのでテンプレート化において表示内容がかわってなければ問題ないですmm）

## スクリーンショット

### トップページ

| before | after |
| --- | --- |
| <img width="360" alt="takizawa-hackathon com" src="https://github.com/takizawa-hackathon/takizawa-hackathon.github.io/assets/18627288/185a6be2-cb72-4a2a-8295-a07762911b3e" /> | <img width="360" alt="localhost_4000" src="https://github.com/takizawa-hackathon/takizawa-hackathon.github.io/assets/18627288/9f95ce18-290b-4fc7-a47b-e82f18963190" /> |

### スポンサー募集

| before | after |
| --- | --- |
| <img width="360" alt="takizawa-hackathon com_sponsorship" src="https://github.com/takizawa-hackathon/takizawa-hackathon.github.io/assets/18627288/5db38e9d-afed-4620-86e1-2061dacaf3b5" /> | <img width="360" alt="localhost_4000_sponsorship" src="https://github.com/takizawa-hackathon/takizawa-hackathon.github.io/assets/18627288/a1eb4661-dd5d-477f-97ab-1a322f4f09e6" /> |

### プライバシーポリシー

| before | after |
| --- | --- |
| <img width="360" alt="takizawa-hackathon com_privacy" src="https://github.com/takizawa-hackathon/takizawa-hackathon.github.io/assets/18627288/eb77675e-7f15-4550-b58e-32f7302eae81" /> | <img width="360" alt="localhost_4000_privacy" src="https://github.com/takizawa-hackathon/takizawa-hackathon.github.io/assets/18627288/28a974e2-23ec-403a-beb2-8a7375e0e62c" /> |
