### PR TITLE
Ver.6 スポンサー募集の終了

### DIFF
--- a/sponsorship/index.html
+++ b/sponsorship/index.html
@@ -11,7 +11,13 @@ custom_css: "/css/sponsorship.css"
     <div class="top-message">
       <p>Takizawa Hackathonを共に盛り上げてくださるスポンサーを募集しています。</p>
     </div>
-    <h3>募集中のスポンサー</h3>
+    <h3><s>募集中のスポンサー</s></h3>
+    <p>
+      <b>（2024/05/28 更新）</b><br>
+      Ver.6 のスポンサーの募集を終了させていただきました。<br>
+      なお、次回イベントの開催が決定した際に、改めて本ページにて募集再開の旨をお知らせさせていただきます。<br>
+      多くのご応募をいただきまして誠にありがとうございました。
+    </p>
     <ul>
       <li>
         <b>イベントインフラサポート</b>
@@ -140,10 +146,16 @@ custom_css: "/css/sponsorship.css"
       </li>
     </ul>
     <h3>お申し込み方法</h3>
-    <p>以下Googleフォームよりご連絡先とご希望のプランをお知らせください。</p>
+    <p>
+      <s>以下Googleフォームよりご連絡先とご希望のプランをお知らせください。</s><br>
+    </p>
+    <p>
+      <b>（2024/05/28 更新）</b><br>
+      Ver.6 のスポンサーの募集を終了させていただきました。多くのご応募をいただきまして誠にありがとうございました。
+    </p>
     <div class="entry-btn">
-      <a href="https://forms.gle/7WomqFR92wRbKYMA6" class="btn btn-default btn-shadow wf-notosansjapanese"
-        target="_blank">スポンサーになる</a>
+      <a href="" class="btn btn-default btn-shadow wf-notosansjapanese target-event-none"
+        target="_blank">募集を終了しました</a>
     </div>
     <h3>お問い合せ先</h3>
     <p>スポンサー募集に関するお問い合せは下記までご連絡ください。</p>


### PR DESCRIPTION
### 変更点

- スポンサー募集ページ
　- Ver.6のスポンサー募集を終了した旨を記載
　- 応募フォームへのリンクを無効化

### 2024/05/28時点スクショ

![screencapture-127-0-0-1-4000-sponsorship-2024-05-28-21_35_17のコピー](https://github.com/takizawa-hackathon/takizawa-hackathon.github.io/assets/12765236/ebdf510e-bf19-4dbb-8013-07a8d6ab3137)
---
![screencapture-127-0-0-1-4000-sponsorship-2024-05-28-21_35_17](https://github.com/takizawa-hackathon/takizawa-hackathon.github.io/assets/12765236/a12a0eea-40a6-493f-871d-48dafa5925fc)
