### PR TITLE
プリマ研究室を共催に追加（ver9・勉強会）

### DIFF
--- a/_includes/study_event.html
+++ b/_includes/study_event.html
@@ -23,6 +23,9 @@
       {% if page.entry_end_date %}
       <li><i class="fa fa-clock-o" aria-hidden="true"></i> 申込締切: {{ page.entry_end_date | date: "%Y年%m月%d日" }}</li>
       {% endif %}
+      {% if page.co_organizer %}
+      <li><i class="fa fa-building" aria-hidden="true"></i> 共催: {{ page.co_organizer }}</li>
+      {% endif %}
     </ul>
   </div>
   {% if page.status == "open" and page.form_url != "" and page.form_url != "#" %}

--- a/_study_events/gemini-api-ai-product.html
+++ b/_study_events/gemini-api-ai-product.html
@@ -8,6 +8,7 @@ target: 岩手県内の学生（開発経験がなくてもOK）
 capacity: "20名"
 entry_end_date: 2026-05-31
 form_url: "https://forms.gle/c8unk1XhmzWhAU9PA"
+co_organizer: プリマ研究室
 status: upcoming
 ---
 

--- a/index.html
+++ b/index.html
@@ -168,7 +168,8 @@ form_url: https://forms.gle/gsrPR88pKhfGrAjZ8
               <br>
               参加資格：岩手県内の学生<br>
               参加費：無料<br>
-              運営元：滝沢ハッカソン運営委員会
+              運営元：滝沢ハッカソン運営委員会<br>
+              共催：プリマ研究室
               <br><br>
               {% if page.postponement_form_deadline %}
               <strong>エントリー締め切り：<br><del>{{ page.form_deadline }}</del></strong><br>


### PR DESCRIPTION
## Summary

- `index.html`: Takizawa Hackathon Ver.9 のイベント情報に「共催：プリマ研究室」を追加
- `_study_events/gemini-api-ai-product.html`: 勉強会イベントのフロントマターに `co_organizer: プリマ研究室` を追加
- `_includes/study_event.html`: `co_organizer` フィールドが存在する場合に共催を表示するテンプレートを追加

## Test plan

- [ ] ver9 トップページのイベント情報に「共催：プリマ研究室」が表示されることを確認
- [ ] 勉強会ページのイベントカードに「共催: プリマ研究室」が表示されることを確認
- [ ] 他の勉強会イベント（`co_organizer` 未設定）には影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)